### PR TITLE
replace bignum with big-integer lib for better node versions compatib…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,31 +4,28 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "bignum": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/bignum/-/bignum-0.11.0.tgz",
-      "integrity": "sha1-YyXytsDnTJ9MFo7H4l/TrLimNIQ=",
-      "requires": {
-        "nan": "2.10.0"
-      }
+    "big-integer": {
+      "version": "1.6.48",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
+    },
+    "crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "2.1.2"
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "rsa-pem-from-mod-exp": {
       "version": "0.8.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,6 @@
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
       "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
     },
-    "crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
-    },
     "debug": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "homepage": "https://github.com/egnyte/wopi-proof-validator#readme",
   "dependencies": {
     "big-integer": "^1.6.48",
-    "crypto": "^1.0.1",
     "debug": "^4.2.0",
     "rsa-pem-from-mod-exp": "^0.8.4"
   }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   },
   "homepage": "https://github.com/egnyte/wopi-proof-validator#readme",
   "dependencies": {
-    "bignum": "0.13.0"
+    "big-integer": "^1.6.48",
+    "crypto": "^1.0.1",
+    "debug": "^4.2.0",
+    "rsa-pem-from-mod-exp": "^0.8.4"
   }
 }

--- a/src/payloadBuilder.js
+++ b/src/payloadBuilder.js
@@ -1,4 +1,23 @@
-const bignum = require("bignum");
+const BigInteger = require('big-integer');
+
+// taken from https://stackoverflow.com/questions/48521840/biginteger-to-a-uint8array-of-bytes
+const zero = BigInteger(0);
+const n256 = BigInteger(256);
+
+function toLittleEndian(bigNumber) {
+    let result = new Uint8Array(8);
+    let i = 0;
+    while (bigNumber.greater(zero)) {
+        result[i] = bigNumber.mod(n256);
+        bigNumber = bigNumber.divide(n256);
+        i += 1;
+    }
+    return result;
+}
+
+function toBigEndian(bytes) {
+    return toLittleEndian(bytes).reverse();
+}
 
 module.exports = {
     build: function(input) {
@@ -7,10 +26,7 @@ module.exports = {
         const fullUrlBuffer = Buffer.from(fullUrl, "utf8");
         const accessTokenBuffer = Buffer.from(input.accessToken, "utf8");
 
-        const timeBuffer = bignum(input.timestamp).toBuffer({
-            endian: "big",
-            size: 8
-        });
+        const timeBuffer = toBigEndian(BigInteger(input.timestamp))
 
         const expectedProofBuffer = Buffer.concat([
             getLengthIn4Bytes(accessTokenBuffer),

--- a/src/timeConverter.js
+++ b/src/timeConverter.js
@@ -1,11 +1,12 @@
-const bignum = require("bignum");
-const milisecondEpochDiff = 62135596800000;
+const BigInteger = require('big-integer');
+
+const milisecondEpochDiff = BigInteger('62135596800000');
 
 module.exports = function(timeString) {
-    var time = bignum(timeString);
+    var time = BigInteger(timeString);
     var approximateTimestamp = time
-        .div(10000)
-        .sub(milisecondEpochDiff)
-        .toNumber();
+        .divide(10000)
+        .subtract(milisecondEpochDiff)
+        .valueOf();
     return approximateTimestamp;
 };


### PR DESCRIPTION
#### What’s this PR do?
Replaces the bignum lib for the big-integer one. This allows better compatibility with the latest node versions.

All tests are passing.